### PR TITLE
Fix docker scripts to preserve host paths

### DIFF
--- a/docker/docker_build_win64.sh
+++ b/docker/docker_build_win64.sh
@@ -6,13 +6,19 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 PROJECT_ROOT="$( dirname "$SCRIPT_DIR" )"
 
 IMAGE_NAME=machines-cpp-dev
-WORKDIR=/opt/dev
+
+# Use the same working directory path inside the container as on the host so
+# that generated build files do not reference an inaccessible location (e.g.
+# /opt/dev).  A custom path can be provided via the CONTAINER_WORKDIR
+# environment variable if required.
+HOST_WORKDIR="${PROJECT_ROOT}"
+CONTAINER_WORKDIR="${CONTAINER_WORKDIR:-${HOST_WORKDIR}}"
 
 # Run cmake + make inside the container, mounting the project root
 docker run --rm \
-  -v "${PROJECT_ROOT}:${WORKDIR}" \
-  -w "${WORKDIR}" \
-  ${IMAGE_NAME} \
+  -v "${HOST_WORKDIR}:${CONTAINER_WORKDIR}" \
+  -w "${CONTAINER_WORKDIR}" \
+  "${IMAGE_NAME}" \
   bash -c "
     rm -rf buildMingw64 &&
     mkdir buildMingw64 &&

--- a/docker/docker_shell.sh
+++ b/docker/docker_shell.sh
@@ -5,15 +5,20 @@ then
 fi
 
 IMAGE_NAME=machines-cpp-dev
-WORKDIR=/opt/dev
-MOUNTS="$(pwd):${WORKDIR}"
 
-DOCKER_CMD="docker run -it \
-            -v $MOUNTS \
-            -w ${WORKDIR} \
-            ${IMAGE_NAME} \
-            bash"
+# Use the project directory on the host as the working directory inside the
+# container.  This prevents CMake from hardcoding an inaccessible path (e.g.
+# /opt/dev) into its cache which would later break local builds once the
+# container exits.  Users can override the container path by setting the
+# CONTAINER_WORKDIR environment variable when invoking the script.
+HOST_WORKDIR="$(pwd)"
+CONTAINER_WORKDIR="${CONTAINER_WORKDIR:-${HOST_WORKDIR}}"
+MOUNTS="${HOST_WORKDIR}:${CONTAINER_WORKDIR}"
 
 set -e
 echo "Logging into docker shell"
-$DOCKER_CMD
+docker run -it \
+  -v "${MOUNTS}" \
+  -w "${CONTAINER_WORKDIR}" \
+  "${IMAGE_NAME}" \
+  bash


### PR DESCRIPTION
## Summary
- update docker helper scripts to mount the project root at the same path inside the container
- allow overriding the in-container workdir via the CONTAINER_WORKDIR environment variable
- quote docker arguments so host paths with spaces work correctly

## Testing
- bash -n docker/docker_shell.sh
- bash -n docker/docker_build_win64.sh

------
https://chatgpt.com/codex/tasks/task_e_68cdd4c4ad648332ad041a97aab6b53c